### PR TITLE
인증 정보 전파

### DIFF
--- a/src/main/java/me/jaeyeopme/sns/common/annotation/SessionPrincipal.java
+++ b/src/main/java/me/jaeyeopme/sns/common/annotation/SessionPrincipal.java
@@ -1,0 +1,14 @@
+package me.jaeyeopme.sns.common.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SessionPrincipal {
+
+}

--- a/src/main/java/me/jaeyeopme/sns/common/aspect/SessionRequiredAspect.java
+++ b/src/main/java/me/jaeyeopme/sns/common/aspect/SessionRequiredAspect.java
@@ -1,6 +1,7 @@
 package me.jaeyeopme.sns.common.aspect;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import me.jaeyeopme.sns.common.security.SessionContext;
 import me.jaeyeopme.sns.session.application.SessionFacade;
 import org.aspectj.lang.annotation.After;
@@ -8,6 +9,7 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Aspect
 @Component
 @RequiredArgsConstructor
@@ -15,14 +17,18 @@ public class SessionRequiredAspect {
 
     private final SessionFacade sessionFacade;
 
+    private final SessionContext sessionContext;
+
     @Before("@annotation(me.jaeyeopme.sns.common.annotation.SessionRequired)")
     public void beforeSessionRequired() {
-        SessionContext.set(sessionFacade.getPrincipal());
+        final var principal = sessionFacade.principal();
+        sessionContext.principal(principal);
+        log.debug("SessionRequired Aspect ID: {}, EMAIL: {}", principal.id(), principal.email());
     }
 
     @After("@annotation(me.jaeyeopme.sns.common.annotation.SessionRequired)")
     public void afterSessionRequired() {
-        SessionContext.clear();
+        sessionContext.clear();
     }
 
 }

--- a/src/main/java/me/jaeyeopme/sns/common/config/WebConfig.java
+++ b/src/main/java/me/jaeyeopme/sns/common/config/WebConfig.java
@@ -1,0 +1,21 @@
+package me.jaeyeopme.sns.common.config;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import me.jaeyeopme.sns.common.resolver.SessionArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final SessionArgumentResolver sessionArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(sessionArgumentResolver);
+    }
+
+}

--- a/src/main/java/me/jaeyeopme/sns/common/resolver/SessionArgumentResolver.java
+++ b/src/main/java/me/jaeyeopme/sns/common/resolver/SessionArgumentResolver.java
@@ -1,0 +1,32 @@
+package me.jaeyeopme.sns.common.resolver;
+
+import lombok.RequiredArgsConstructor;
+import me.jaeyeopme.sns.common.annotation.SessionPrincipal;
+import me.jaeyeopme.sns.common.security.SessionContext;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class SessionArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final SessionContext sessionContext;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(SessionPrincipal.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter,
+        final ModelAndViewContainer mavContainer,
+        final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory)
+        throws Exception {
+        return sessionContext.principal();
+    }
+
+}

--- a/src/main/java/me/jaeyeopme/sns/common/security/SessionContext.java
+++ b/src/main/java/me/jaeyeopme/sns/common/security/SessionContext.java
@@ -1,20 +1,24 @@
 package me.jaeyeopme.sns.common.security;
 
+import lombok.RequiredArgsConstructor;
 import me.jaeyeopme.sns.session.domain.Principal;
+import org.springframework.stereotype.Component;
 
+@RequiredArgsConstructor
+@Component
 public class SessionContext {
 
     private final static ThreadLocal<Principal> sessionContext = new ThreadLocal<>();
 
-    public static Principal get() {
+    public Principal principal() {
         return sessionContext.get();
     }
 
-    public static void set(final Principal principal) {
+    public void principal(final Principal principal) {
         sessionContext.set(principal);
     }
 
-    public static void clear() {
+    public void clear() {
         sessionContext.remove();
     }
 

--- a/src/main/java/me/jaeyeopme/sns/post/application/PostFacade.java
+++ b/src/main/java/me/jaeyeopme/sns/post/application/PostFacade.java
@@ -1,0 +1,20 @@
+package me.jaeyeopme.sns.post.application;
+
+import lombok.RequiredArgsConstructor;
+import me.jaeyeopme.sns.post.application.service.PostService;
+import me.jaeyeopme.sns.post.domain.Post;
+import me.jaeyeopme.sns.post.presentation.dto.PostCreateRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostFacade {
+
+    private final PostService postService;
+
+    public Long create(final PostCreateRequest request,
+        final Long ownerId) {
+        return postService.create(Post.of(request, ownerId));
+    }
+
+}

--- a/src/main/java/me/jaeyeopme/sns/post/application/service/PostService.java
+++ b/src/main/java/me/jaeyeopme/sns/post/application/service/PostService.java
@@ -1,0 +1,9 @@
+package me.jaeyeopme.sns.post.application.service;
+
+import me.jaeyeopme.sns.post.domain.Post;
+
+public interface PostService {
+
+    Long create(Post post);
+
+}

--- a/src/main/java/me/jaeyeopme/sns/post/domain/Caption.java
+++ b/src/main/java/me/jaeyeopme/sns/post/domain/Caption.java
@@ -3,21 +3,23 @@ package me.jaeyeopme.sns.post.domain;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
-import javax.persistence.Lob;
+import javax.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
 public class Caption {
 
     @JsonProperty("caption")
-    @Lob
-    @Column(name = "caption")
+    @Size(max = 2000, message = "최대 {max}자 까지만 입력할 수 있습니다.")
+    @Column(name = "caption", length = 2000)
     private String value;
 
 }

--- a/src/main/java/me/jaeyeopme/sns/post/domain/Caption.java
+++ b/src/main/java/me/jaeyeopme/sns/post/domain/Caption.java
@@ -1,0 +1,23 @@
+package me.jaeyeopme.sns.post.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.Lob;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class Caption {
+
+    @JsonProperty("caption")
+    @Lob
+    @Column(name = "caption")
+    private String value;
+
+}

--- a/src/main/java/me/jaeyeopme/sns/post/domain/Post.java
+++ b/src/main/java/me/jaeyeopme/sns/post/domain/Post.java
@@ -1,0 +1,45 @@
+package me.jaeyeopme.sns.post.domain;
+
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.jaeyeopme.sns.post.presentation.dto.PostCreateRequest;
+import me.jaeyeopme.sns.user.domain.User;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Post {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @Embedded
+    private Caption caption;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "owner_id")
+    private User owner;
+
+    public static Post of(final PostCreateRequest request,
+        final Long ownerId) {
+        return Post.builder()
+            .caption(request.caption())
+            .owner(User.reference(ownerId))
+            .build();
+    }
+
+}

--- a/src/main/java/me/jaeyeopme/sns/post/presentation/PostRestController.java
+++ b/src/main/java/me/jaeyeopme/sns/post/presentation/PostRestController.java
@@ -1,0 +1,38 @@
+package me.jaeyeopme.sns.post.presentation;
+
+import java.net.URI;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import me.jaeyeopme.sns.common.annotation.SessionPrincipal;
+import me.jaeyeopme.sns.common.annotation.SessionRequired;
+import me.jaeyeopme.sns.common.exception.dto.SNSResponse;
+import me.jaeyeopme.sns.post.application.PostFacade;
+import me.jaeyeopme.sns.post.presentation.dto.PostCreateRequest;
+import me.jaeyeopme.sns.session.domain.Principal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping(PostRestController.URL)
+@RestController
+@RequiredArgsConstructor
+public class PostRestController {
+
+    public static final String URL = "/api/v1/posts";
+
+    private final PostFacade postFacade;
+
+    @SessionRequired
+    @PostMapping
+    public ResponseEntity<SNSResponse<Void>> create(
+        @SessionPrincipal final Principal principal,
+        @RequestBody @Valid final PostCreateRequest request) {
+        final var postId = postFacade.create(request, principal.id());
+        final var location = URI.create("%s/%s".formatted(URL, postId));
+
+        return SNSResponse.create(location);
+    }
+
+}

--- a/src/main/java/me/jaeyeopme/sns/post/presentation/dto/PostCreateRequest.java
+++ b/src/main/java/me/jaeyeopme/sns/post/presentation/dto/PostCreateRequest.java
@@ -1,0 +1,22 @@
+package me.jaeyeopme.sns.post.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import javax.validation.Valid;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.jaeyeopme.sns.post.domain.Caption;
+
+@Getter
+@EqualsAndHashCode
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostCreateRequest {
+
+    @JsonUnwrapped
+    @Valid
+    private Caption caption;
+
+}

--- a/src/main/java/me/jaeyeopme/sns/session/application/SessionFacade.java
+++ b/src/main/java/me/jaeyeopme/sns/session/application/SessionFacade.java
@@ -29,8 +29,8 @@ public class SessionFacade {
         sessionService.invalidate();
     }
 
-    public Principal getPrincipal() {
-        return sessionService.getPrincipal();
+    public Principal principal() {
+        return sessionService.principal();
     }
 
 }

--- a/src/main/java/me/jaeyeopme/sns/session/application/service/GeneralSessionService.java
+++ b/src/main/java/me/jaeyeopme/sns/session/application/service/GeneralSessionService.java
@@ -1,6 +1,7 @@
 package me.jaeyeopme.sns.session.application.service;
 
 import lombok.RequiredArgsConstructor;
+import me.jaeyeopme.sns.common.exception.InvalidSessionException;
 import me.jaeyeopme.sns.session.domain.Principal;
 import me.jaeyeopme.sns.session.domain.repository.SessionRepository;
 import org.springframework.stereotype.Service;
@@ -22,8 +23,9 @@ public class GeneralSessionService implements SessionService {
     }
 
     @Override
-    public Principal getPrincipal() {
-        return sessionRepository.getPrincipal();
+    public Principal principal() {
+        return sessionRepository.principal()
+            .orElseThrow(InvalidSessionException::new);
     }
 
 }

--- a/src/main/java/me/jaeyeopme/sns/session/application/service/SessionService.java
+++ b/src/main/java/me/jaeyeopme/sns/session/application/service/SessionService.java
@@ -8,6 +8,6 @@ public interface SessionService {
 
     void invalidate();
 
-    Principal getPrincipal();
+    Principal principal();
 
 }

--- a/src/main/java/me/jaeyeopme/sns/session/domain/repository/SessionRepository.java
+++ b/src/main/java/me/jaeyeopme/sns/session/domain/repository/SessionRepository.java
@@ -1,5 +1,6 @@
 package me.jaeyeopme.sns.session.domain.repository;
 
+import java.util.Optional;
 import me.jaeyeopme.sns.session.domain.Principal;
 
 public interface SessionRepository {
@@ -8,6 +9,6 @@ public interface SessionRepository {
 
     void invalidate();
 
-    Principal getPrincipal();
+    Optional<Principal> principal();
 
 }

--- a/src/main/java/me/jaeyeopme/sns/session/infrastructure/InMemorySessionRepository.java
+++ b/src/main/java/me/jaeyeopme/sns/session/infrastructure/InMemorySessionRepository.java
@@ -3,7 +3,6 @@ package me.jaeyeopme.sns.session.infrastructure;
 import java.util.Optional;
 import javax.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
-import me.jaeyeopme.sns.common.exception.InvalidSessionException;
 import me.jaeyeopme.sns.session.domain.Principal;
 import me.jaeyeopme.sns.session.domain.repository.SessionRepository;
 import org.springframework.stereotype.Repository;
@@ -27,9 +26,8 @@ public class InMemorySessionRepository implements SessionRepository {
     }
 
     @Override
-    public Principal getPrincipal() {
-        return (Principal) Optional.ofNullable(session.getAttribute(SESSION_NAME))
-            .orElseThrow(InvalidSessionException::new);
+    public Optional<Principal> principal() {
+        return Optional.ofNullable((Principal) session.getAttribute(SESSION_NAME));
     }
 
 }

--- a/src/main/java/me/jaeyeopme/sns/user/domain/User.java
+++ b/src/main/java/me/jaeyeopme/sns/user/domain/User.java
@@ -53,4 +53,10 @@ public class User {
             .build();
     }
 
+    public static User reference(final Long id) {
+        return User.builder()
+            .id(id)
+            .build();
+    }
+
 }

--- a/src/test/java/me/jaeyeopme/sns/config/RestDocsConfig.java
+++ b/src/test/java/me/jaeyeopme/sns/config/RestDocsConfig.java
@@ -11,9 +11,10 @@ import org.springframework.restdocs.snippet.Attributes;
 @TestConfiguration
 public class RestDocsConfig {
 
-    public static Attributes.Attribute field(final String key,
-        final String value) {
-        return new Attributes.Attribute(key, value);
+    private static final String CONSTRAINTS = "constraints";
+
+    public static Attributes.Attribute constraintField(final String value) {
+        return new Attributes.Attribute(CONSTRAINTS, value);
     }
 
     @Bean

--- a/src/test/java/me/jaeyeopme/sns/support/RestControllerTest.java
+++ b/src/test/java/me/jaeyeopme/sns/support/RestControllerTest.java
@@ -3,6 +3,9 @@ package me.jaeyeopme.sns.support;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 import me.jaeyeopme.sns.common.aspect.SessionRequiredAspect;
+import me.jaeyeopme.sns.common.security.SessionContext;
+import me.jaeyeopme.sns.post.application.PostFacade;
+import me.jaeyeopme.sns.post.presentation.PostRestController;
 import me.jaeyeopme.sns.session.application.SessionFacade;
 import me.jaeyeopme.sns.session.presentation.SessionRestController;
 import me.jaeyeopme.sns.user.application.UserFacade;
@@ -19,18 +22,25 @@ import org.springframework.test.web.servlet.MockMvc;
     SessionRequiredAspect.class,
 })
 @WebMvcTest({
+    UserRestController.class,
     SessionRestController.class,
-    UserRestController.class
+    PostRestController.class,
 })
 public abstract class RestControllerTest {
 
     protected MockMvc mockMvc;
 
     @MockBean
+    protected SessionContext sessionContext;
+
+    @MockBean
     protected UserFacade userFacade;
 
     @MockBean
     protected SessionFacade sessionFacade;
+
+    @MockBean
+    protected PostFacade postFacade;
 
     @Autowired
     private ObjectMapper objectMapper;

--- a/src/test/java/me/jaeyeopme/sns/support/fixture/PostFixture.java
+++ b/src/test/java/me/jaeyeopme/sns/support/fixture/PostFixture.java
@@ -1,0 +1,12 @@
+package me.jaeyeopme.sns.support.fixture;
+
+import me.jaeyeopme.sns.post.domain.Caption;
+import me.jaeyeopme.sns.post.presentation.dto.PostCreateRequest;
+
+public class PostFixture {
+
+    public static final Caption CAPTION = new Caption("caption");
+
+    public static final PostCreateRequest POST_CREATE_REQUEST = new PostCreateRequest(CAPTION);
+
+}

--- a/src/test/java/me/jaeyeopme/sns/unit/post/PostRestControllerTest.java
+++ b/src/test/java/me/jaeyeopme/sns/unit/post/PostRestControllerTest.java
@@ -1,0 +1,63 @@
+package me.jaeyeopme.sns.unit.post;
+
+import static me.jaeyeopme.sns.config.RestDocsConfig.constraintField;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import lombok.SneakyThrows;
+import me.jaeyeopme.sns.post.presentation.PostRestController;
+import me.jaeyeopme.sns.support.fixture.PostFixture;
+import me.jaeyeopme.sns.support.fixture.UserFixture;
+import me.jaeyeopme.sns.support.restdocs.RestDocsTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public class PostRestControllerTest extends RestDocsTestSupport {
+
+    @SneakyThrows
+    @DisplayName("게시물 생성에 성공한다.")
+    @Test
+    void 게시물_생성_성공() {
+        // GIVEN
+        final var principal = UserFixture.PRINCIPAL;
+        final var request = PostFixture.POST_CREATE_REQUEST;
+        given(sessionFacade.principal()).willReturn(principal);
+        given(sessionContext.principal()).willReturn(principal);
+        given(postFacade.create(request, principal.id())).willReturn(principal.id());
+
+        // WHEN
+        final var when = mockMvc.perform(post(PostRestController.URL)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(createJson(request)));
+
+        // THEN
+        when.andExpectAll(status().isCreated(),
+            header().string(HttpHeaders.LOCATION,
+                "%s/%s".formatted(PostRestController.URL, 1L)));
+        then(postFacade).should().create(request, principal.id());
+
+        // ASPECT
+        then(sessionFacade).should().principal();
+        then(sessionContext).should().principal(principal);
+
+        // RESOLVER
+        then(sessionContext).should().principal();
+
+        // DOCS
+        when.andDo(document(
+            requestFields(
+                fieldWithPath("caption").type(JsonFieldType.STRING).description("게시물에 대한 설명")
+                    .optional().attributes(constraintField("2000자 이내"))
+            )
+        ));
+    }
+
+}

--- a/src/test/java/me/jaeyeopme/sns/unit/session/application/GeneralSessionServiceTest.java
+++ b/src/test/java/me/jaeyeopme/sns/unit/session/application/GeneralSessionServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.only;
 
+import java.util.Optional;
 import me.jaeyeopme.sns.common.exception.InvalidSessionException;
 import me.jaeyeopme.sns.session.application.service.GeneralSessionService;
 import me.jaeyeopme.sns.session.domain.repository.SessionRepository;
@@ -66,35 +67,35 @@ class GeneralSessionServiceTest {
 
     @DisplayName("세션 조회 시")
     @Nested
-    public class When_GetPrincipal {
+    public class When_GetSessionPrincipal {
 
         @DisplayName("유효하지 않은 세션인 경우 실패한다.")
         @Test
         void Given_InvalidSession_Then_ThrowException() {
             // GIVEN
-            willThrow(InvalidSessionException.class).given(sessionRepository).getPrincipal();
+            willThrow(InvalidSessionException.class).given(sessionRepository).principal();
 
             // WHEN
-            final Executable when = () -> sessionService.getPrincipal();
+            final Executable when = () -> sessionService.principal();
 
             // THEN
             assertThrows(InvalidSessionException.class, when);
-            then(sessionRepository).should(only()).getPrincipal();
+            then(sessionRepository).should(only()).principal();
         }
 
         @DisplayName("유효한 세션인 경우 성공한다.")
         @Test
         void Given_ValidSession_Then_ReturnPrincipal() {
             // GIVEN
-            final var expected = UserFixture.PRINCIPAL;
-            given(sessionRepository.getPrincipal()).willReturn(expected);
+            final var expected = Optional.of(UserFixture.PRINCIPAL);
+            given(sessionRepository.principal()).willReturn(expected);
 
             // WHEN
-            final var actual = sessionService.getPrincipal();
+            final var actual = sessionService.principal();
 
             // THEN
-            assertThat(actual).isEqualTo(expected);
-            then(sessionRepository).should(only()).getPrincipal();
+            assertThat(actual).isEqualTo(expected.get());
+            then(sessionRepository).should(only()).principal();
         }
 
     }

--- a/src/test/java/me/jaeyeopme/sns/unit/session/presentation/SessionRestControllerTest.java
+++ b/src/test/java/me/jaeyeopme/sns/unit/session/presentation/SessionRestControllerTest.java
@@ -1,6 +1,6 @@
 package me.jaeyeopme.sns.unit.session.presentation;
 
-import static me.jaeyeopme.sns.config.RestDocsConfig.field;
+import static me.jaeyeopme.sns.config.RestDocsConfig.constraintField;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
@@ -93,9 +93,9 @@ public class SessionRestControllerTest extends RestDocsTestSupport {
         when.andDo(document(
             requestFields(
                 fieldWithPath("email").type(JsonFieldType.STRING).description("이메일")
-                    .attributes(field("constraints", "이메일 형식")),
+                    .attributes(constraintField("이메일 형식")),
                 fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
-                    .attributes(field("constraints", "최소 8자, 최소 하나의 문자 및 하나의 숫자"))
+                    .attributes(constraintField("최소 8자, 최소 하나의 문자 및 하나의 숫자"))
             )
         ));
     }
@@ -147,7 +147,7 @@ public class SessionRestControllerTest extends RestDocsTestSupport {
     @Test
     void 세션_만료_실패_유효하지_않은_세션인_경우() {
         // GIVEN
-        willThrow(new InvalidSessionException()).given(sessionFacade).getPrincipal();
+        willThrow(new InvalidSessionException()).given(sessionFacade).principal();
 
         // WHEN
         final var when = mockMvc.perform(
@@ -156,7 +156,7 @@ public class SessionRestControllerTest extends RestDocsTestSupport {
 
         // THEN
         when.andExpectAll(status().isUnauthorized());
-        then(sessionFacade).should(only()).getPrincipal();
+        then(sessionFacade).should(only()).principal();
     }
 
     @SneakyThrows
@@ -165,7 +165,7 @@ public class SessionRestControllerTest extends RestDocsTestSupport {
     void 세션_만료_성공() {
         // GIVEN
         final var principal = UserFixture.PRINCIPAL;
-        given(sessionFacade.getPrincipal()).willReturn(principal);
+        given(sessionFacade.principal()).willReturn(principal);
 
         // WHEN
         final var when = mockMvc.perform(
@@ -174,7 +174,7 @@ public class SessionRestControllerTest extends RestDocsTestSupport {
 
         // THEN
         when.andExpectAll(status().isOk());
-        then(sessionFacade).should().getPrincipal();
+        then(sessionFacade).should().principal();
         then(sessionFacade).should().invalidate();
 
         // DOCS

--- a/src/test/java/me/jaeyeopme/sns/unit/user/presentation/UserRestControllerTest.java
+++ b/src/test/java/me/jaeyeopme/sns/unit/user/presentation/UserRestControllerTest.java
@@ -1,6 +1,6 @@
 package me.jaeyeopme.sns.unit.user.presentation;
 
-import static me.jaeyeopme.sns.config.RestDocsConfig.field;
+import static me.jaeyeopme.sns.config.RestDocsConfig.constraintField;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willDoNothing;
@@ -90,15 +90,15 @@ public class UserRestControllerTest extends RestDocsTestSupport {
         when.andDo(document(
             requestFields(
                 fieldWithPath("email").type(JsonFieldType.STRING).description("이메일")
-                    .attributes(field("constraints", "이메일 형식")),
+                    .attributes(constraintField("이메일 형식")),
                 fieldWithPath("phone").type(JsonFieldType.STRING).description("전화번호")
-                    .attributes(field("constraints", "13자 이내")),
+                    .attributes(constraintField("13자 이내")),
                 fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
-                    .attributes(field("constraints", "최소 8자, 최소 하나의 문자 및 하나의 숫자")),
+                    .attributes(constraintField("최소 8자, 최소 하나의 문자 및 하나의 숫자")),
                 fieldWithPath("name").type(JsonFieldType.STRING).description("이름")
-                    .attributes(field("constraints", "20자 이내")),
+                    .attributes(constraintField("20자 이내")),
                 fieldWithPath("bio").type(JsonFieldType.STRING).description("소개")
-                    .attributes(field("constraints", "50자 이내"))
+                    .attributes(constraintField("50자 이내"))
                     .optional()
             )
         ));


### PR DESCRIPTION
Session 조회 후 ThreadLocal 저장소에 저장하여 SessionPrincipal 어노테이션 & SessionArgumentResolver 로 인증 객체를 전파한다.
Spring Boot 내장 Tomcat 은 Thread Pool 을 사용하기 때문에 요청이 끝난 후 SessionRequiredAspect 에서 Thread 의 재사용을 위해 ThreadLocal 저장소를 비워주는 작업을 한다.